### PR TITLE
Initialize git repo if there is no current .git folder

### DIFF
--- a/app/controllers/web_git/commands_controller.rb
+++ b/app/controllers/web_git/commands_controller.rb
@@ -4,8 +4,15 @@ module WebGit
 
     def status
       Dir.chdir(Rails.root) do
+        
+        unless Dir.exist?(".git")
+          puts "Initialize a git repository"
+          `git init`
+          `git add -A`
+          puts "Make first commit"
+          `git commit -m "Starting point"`
+        end
         @status = `git status`
-
         @current_branch = `git symbolic-ref --short HEAD`.chomp
 
         @origin_url = nil


### PR DESCRIPTION
When students create the workspace for their assignment with Codio, there is no `.git` folder or history which will cause WebGit to silently fail. #25 

These changes will look for `.git` and if the folder doesn't exist, WebGit will initialize the repository and make an initial commit of all files.