### PR TITLE
Enable Buttons

### DIFF
--- a/app/views/web_git/commands/status.html.erb
+++ b/app/views/web_git/commands/status.html.erb
@@ -115,7 +115,7 @@
                 <%= simple_format @status %>
               </pre>
 
-              <%= button_to commits_push_url, disabled: true, class: "btn btn-primary btn-block mb-4", data: { toggle: "tooltip", html: true }, title: "<code>git push</code>" do %>
+              <%= button_to commits_push_url, method: "get", class: "btn btn-primary btn-block mb-4", data: { toggle: "tooltip", html: true }, title: "<code>git push</code>" do %>
                 <%= octicon "repo-push", class: "mr-1" %>
 
                 Push to GitHub
@@ -129,7 +129,7 @@
                 <% end %>
               <% end %>
 
-              <%= button_to commits_pull_url, disabled: true, class: "btn btn-primary btn-block mb-4", data: { toggle: "tooltip", html: true }, title: "<code>git pull</code>" do %>
+              <%= button_to commits_pull_url, method: "get", class: "btn btn-primary btn-block mb-4", data: { toggle: "tooltip", html: true }, title: "<code>git pull</code>" do %>
                 <%= octicon "repo-pull", class: "mr-1" %>
 
                 Pull from GitHub


### PR DESCRIPTION
Fixes #33 

Since we're on Gitpod and can actually _use_ git remotes. Let's do it 😎 

Test with 

```ruby
  gem 'web_git', github: 'firstdraft/web_git', branch: 'jw-undisable-buttons'
```

on Gitpod