### PR TITLE
Set upstream for any branch other than master

### DIFF
--- a/app/controllers/web_git/commits_controller.rb
+++ b/app/controllers/web_git/commits_controller.rb
@@ -28,6 +28,15 @@ module WebGit
       redirect_to root_url, notice: "Pushed to GitHub."
     end
 
+    def set_upstream
+      current_branch = `git symbolic-ref --short HEAD`.chomp
+      Dir.chdir(Rails.root) do
+        @result = `git push -u origin #{current_branch}`
+      end
+
+      redirect_to root_url, notice: "Pushed to GitHub."
+    end
+
     def pull
       current_branch = `git symbolic-ref --short HEAD`.chomp
 

--- a/app/views/web_git/commands/status.html.erb
+++ b/app/views/web_git/commands/status.html.erb
@@ -114,11 +114,19 @@
               <pre>
                 <%= simple_format @status %>
               </pre>
+              
+              <% if @current_branch != "master" %>
+                <%= button_to commits_set_upstream_url, method: "get", class: "btn btn-primary btn-block mb-4", data: { toggle: "tooltip", html: true }, title: "<code>git push -u origin #{@current_branch}</code>" do %>
+                  <%= octicon "repo-push", class: "mr-1" %>
 
-              <%= button_to commits_push_url, method: "get", class: "btn btn-primary btn-block mb-4", data: { toggle: "tooltip", html: true }, title: "<code>git push</code>" do %>
-                <%= octicon "repo-push", class: "mr-1" %>
+                  Push to GitHub
+                <% end %>
+              <% else %>
+                <%= button_to commits_push_url, method: "get", class: "btn btn-primary btn-block mb-4", data: { toggle: "tooltip", html: true }, title: "<code>git push</code>" do %>
+                  <%= octicon "repo-push", class: "mr-1" %>
 
-                Push to GitHub
+                  Push to GitHub
+                <% end %>
               <% end %>
 
               <% if @current_branch != "master" && @origin_url.present? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ WebGit::Engine.routes.draw do
   resources :commits, only: :create
   post "commits/stash"
   get "commits/push"
+  get "commits/set_upstream"
   get "commits/pull"
   get "commits/add"
 end


### PR DESCRIPTION
Fixes #38 

Previously, you could not push a branch to Github, since the button only triggered a `git push` and there would be no upstream for any new branches yet so the push would silently fail.

Now when users try to push any branch other than `master`, they do a `git push -u origin <branchname>`.

Add this branch to a project, `bundle`, and navigating to `/git` to check out the changes.

```ruby
gem 'web_git', github: 'firstdraft/web_git', branch: 'jw-set-upstream-for-new-branch'
```
![image](https://user-images.githubusercontent.com/17581658/68693961-df8e2480-053d-11ea-9826-f651b22dcd83.png)

