### PR TITLE
Make status consistent with CLI status.

### DIFF
--- a/lib/web_git.rb
+++ b/lib/web_git.rb
@@ -39,6 +39,10 @@ module WebGit
     get "/" do
       working_dir = File.exist?(Dir.pwd + "/.git") ? Dir.pwd : Dir.pwd + "/.."
       g = Git.open(working_dir)
+      # Update git index
+      g.status.changed.each do
+        g.diff.entries
+      end
       # Just need the file names
       @changed_files = g.status.changed.keys
       @deleted_files = g.status.added.keys
@@ -52,7 +56,6 @@ module WebGit
         { name: "Added Files:", file_list: @added_files }
       ]
       
-      # TODO shelling out status is different than g.status
       @current_branch = g.current_branch
       # g.branch(@current_branch).checkout # maybe?
       @status = `git status`


### PR DESCRIPTION
Resolves #52 

There appears to be a bug in the `status` method of the `ruby-git` gem that causes it to 
> be easily fooled by operations that don't change the content of a file such as deleting and
recreating it, or even running touch on a file.

ruby-git `status` [behind the scenes](https://github.com/ruby-git/ruby-git/blob/b8c63206f8d10f57892060375a86ae911fad356e/lib/git/status.rb#L160) calls `git diff-files` instead of actual `git status`. `git diff-files` shows[ all changes made to files](https://git-scm.com/docs/git-diff-files) (including mode and modification date changes), but only until `git diff` is called once.

The proposed change should update the index to make it be in sync with the actual contents of the working directory and thus make the `status` method work the same as the CLI command.

You can test these changes by creating a new Gitpod workspace [by clicking this](https://gitpod.io/#https://github.com/appdev-projects/rps-html/tree/mmm).