### PR TITLE
Make the installer reversible

### DIFF
--- a/lib/generators/web_git/install_generator.rb
+++ b/lib/generators/web_git/install_generator.rb
@@ -5,9 +5,6 @@ module WebGit
       log :insert, "Updating config.ru to run apps in parallel."
       
       contents = <<-RUBY.gsub(/^      /, "")
-      # This file is used by Rack-based servers to start the application.
-
-      require_relative 'config/environment'
 
       if Rails.env.development?
         map '/git' do
@@ -15,31 +12,14 @@ module WebGit
         end
       end
 
-      map '/' do
-        run Rails.application
-      end
+      map '/' do\n\t
       RUBY
 
       filename = "config.ru"
       match_text = "run Rails.application"
 
-      # insert_into_file filename, before: match_text do contents
-      # end
-
-      # gsub_file filename, match_text, "\t" + match_text
-      gsub_file filename, match_text, contents
-
-      # append_config
-      
-      # append_file filename do "\nend"
-      # end
-    end
-    
-    private 
-
-    def append_config
-      append_file "config.ru" do "\nend"
-      end
+      insert_into_file filename, contents, before: match_text
+      insert_into_file filename, "\nend", after: match_text, force: true
     end
   end
 end


### PR DESCRIPTION
Use Thor `inject_into_file` which is reversible.

Previously, I wasn't aware of the `force: true` flag  that is required for multiple insertions (for some reason?) so this wasn't possible.

In Gemfile
```ruby
gem "web_git", github: "firstdraft/web_git", branch: "jw-make-reversible-better-installer"
```
In Terminal
```bash
bundle install
rake g web_git:install
rake d web_git:install
```
and `config.ru` should be back to what it was before.