### PR TITLE
Make name of new branch inputs consistent.

### DIFF
--- a/lib/views/status.erb
+++ b/lib/views/status.erb
@@ -243,9 +243,9 @@
               </div>
               
               <div class="form-group">
-                <label for="branch_name_sha">Branch name</label>
-                <input type="text" class="form-control" name="branch_name_sha"
-                  id="branch_name_sha" placeholder="Enter a name for the new branch..."
+                <label for="branch_name">Branch name</label>
+                <input type="text" class="form-control" name="branch_name"
+                  id="branch_name" placeholder="Enter a name for the new branch..."
                   required >
               </div>
 

--- a/lib/web_git.rb
+++ b/lib/web_git.rb
@@ -117,8 +117,8 @@ module WebGit
     post "/branch/checkout" do
       working_dir = File.exist?(Dir.pwd + "/.git") ? Dir.pwd : Dir.pwd + "/.."
       g = Git.open(working_dir)
-      name = params[:branch_name].downcase.gsub(" ", "_")
-      commit = params[:commit_hash]
+      name = params.fetch(:branch_name).downcase.gsub(" ", "_")
+      commit = params.fetch(:commit_hash)
       branches = g.branches.local.map(&:full)
       if branches.include?(name) || commit.nil? 
         g.branch(name).checkout


### PR DESCRIPTION
Resolves #70 

I originally mistook this for https://github.com/firstdraft/appdev/issues/283

When creating a branch off of a specific commit, it will actually fail b/c of 

<img width="1079" alt="Screen Shot 2020-06-08 at 2 00 52 PM" src="https://user-images.githubusercontent.com/17581658/84070816-57b4af80-a992-11ea-9b99-157b65b4ddcd.png">

This is because the `name` of the input somehow become inconsistent with the key being used for `params`.

```erb
<label for="branch_name_sha">Branch name</label>
<input type="text" class="form-control" name="branch_name_sha"
  id="branch_name_sha" placeholder="Enter a name for the new branch..."
  required >
```

So

```ruby
name = params[:branch_name].downcase.gsub(" ", "_")
```

didn't work.

This branch changes the name to be consistent with the other checkout form, `branch_name`.

Test adding this to your Gemfile:
```
gem "web_git", github: "firstdraft/web_git", branch: "jw-fix-checking-out-branch"
```

```
bundle install
rake g web_git:install
```

Enter a commit Hash to check out  a new branch.