### PR TITLE
Graph should end on the branch you were on before creating the graph

### DIFF
--- a/lib/web_git/graph.rb
+++ b/lib/web_git/graph.rb
@@ -25,7 +25,6 @@ module WebGit
       if has_changes
         stash_pop
       end
-
       @full_list
     end
 
@@ -45,6 +44,7 @@ module WebGit
     end
 
     def draw_graph
+      starting_branch = @git.current_branch
       branches = @git.branches.local.map(&:name)
       branches.each do |branch_name|
         branch = { branch: branch_name }
@@ -54,13 +54,14 @@ module WebGit
         branch[:head] = log_commits.last[:sha]
         @full_list.push branch
       end
+      @git.checkout(starting_branch)
 
-       @full_list.each do |branch_hash|
+      @full_list.each do |branch_hash|
         head_sha = branch_hash[:head]
         branch_name = branch_hash[:branch]
 
         if @heads[head_sha].nil?
-          @heads[head_sha] = [ branch_name ]
+          @heads[head_sha] = [branch_name]
         else
           @heads[head_sha].push branch_name
         end


### PR DESCRIPTION
It's possible that you can never stay on a separate branch. Currently the drawing of the graph doesn't take into account what branch you started on _before_ drawing the graph and the last branch name from` g.branches` will always be the branch you end up on.

The proposed changes fix that issue, by noting the current branch _before_ traversing the graph and checking it out before the page is rendered. 


### Test

The usual instructions

```ruby
gem "web_git", git: "https://github.com/firstdraft/web_git", branch: "jw-graph-should-end-on-starting-branch"
```

```bash
bundle install
rails g web_git:install
```