### PR TITLE
Separate Routes for creating a Branch and switching to an existing Branch

### DIFF
--- a/lib/views/status.erb
+++ b/lib/views/status.erb
@@ -175,7 +175,7 @@
                     </li>
 
                     <li class="list-group-item">
-                      <form action="/git/branch/checkout" method="post">
+                      <form action="/git/branch/checkout/new" method="post">
                         <div class="form-group">
                           <label for="branch_name">
                             Go ahead, experiment!
@@ -234,7 +234,7 @@
 
           <div class="card-body">
             <p class="lead">Do you want to jump back in time and go down a different path?</p>
-            <form action="/git/branch/checkout" method="post">
+            <form action="/git/branch/checkout/new" method="post">
               <div class="form-group">
                 <label for="commit_hash">Branch off of</label>
                 <input type="text" class="form-control" name="commit_hash"

--- a/lib/web_git.rb
+++ b/lib/web_git.rb
@@ -99,18 +99,22 @@ module WebGit
       redirect to("/")
     end
     
-    post "/branch/checkout" do
+    post "/branch/checkout/new" do
       working_dir = File.exist?(Dir.pwd + "/.git") ? Dir.pwd : Dir.pwd + "/.."
       g = Git.open(working_dir)
       name = params.fetch(:branch_name).downcase.gsub(" ", "_")
       commit = params.fetch(:commit_hash)
-      branches = g.branches.local.map(&:full)
-      if branches.include?(name) || commit.nil? 
-        g.branch(name).checkout
-      else
-        g.branch(name).checkout
-        g.reset_hard(g.gcommit(commit))
-      end
+      g.branch(name).checkout
+      g.reset_hard(g.gcommit(commit))
+      redirect to("/")
+    end
+    
+    post "/branch/checkout" do
+      working_dir = File.exist?(Dir.pwd + "/.git") ? Dir.pwd : Dir.pwd + "/.."
+      g = Git.open(working_dir)
+      name = params.fetch(:branch_name)
+      g.branch(name).checkout
+      
       redirect to("/")
     end
     


### PR DESCRIPTION
Since we currently aren't doing any redirects with `notices` or `alerts`, it's a lot safe to not use the same Route to create a branch and also checkout one. This led to issues similar to https://github.com/firstdraft/web_git/pull/71 and introduced another bug of using `fetch` that prevents a User from checking out an existing branch.

The proposed changes fix the latter by separating `/branch/checkout` into 
- `/branch/checkout/new` for creating a branch
- `/branch/checkout` for switching to an existing branch
- Updates the form actions accordingly
- Updates the Controller Actions (what do you call them in Sinatra?) accordingly


### Test

The usual instructions

```ruby
gem "web_git", git: "https://github.com/firstdraft/web_git", branch: "jw-make-better-routes-for-branch-checkout"
```

```bash
bundle install
rails g web_git:install
```

