### PR TITLE
Push to any branch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
     erubi (1.8.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    git (1.7.0)
+    git (1.8.1)
       rchardet (~> 1.8)
     github_api (0.18.2)
       addressable (~> 2.4)

--- a/lib/web_git.rb
+++ b/lib/web_git.rb
@@ -131,12 +131,8 @@ module WebGit
       working_dir = File.exist?(Dir.pwd + "/.git") ? Dir.pwd : Dir.pwd + "/.."
       g = Git.open(working_dir)
       # TODO push to heroku eventually, multiple remotes
-      # remote = params[:remote]
-      # unless remote.nil?
-      #   remote = g.remote remote
-      #   g.push remote
-      # end
-      g.push
+
+      g.push('origin', g.current_branch)
       redirect to("/")
     end
 


### PR DESCRIPTION
Resolves #92 

## Problem

It turns out students are unable to push other branches besides `master` to GitHub. This is because with `ruby-git` you have to specify which branch to push,[ otherwise it will default to `"master"`](https://github.com/ruby-git/ruby-git/blob/98270b66b09a9474d6c0ad6d83f384fb4596428a/lib/git/base.rb#L364-L369). Currently, `web_git` does not specify which branch to push. Since the default is `"master"` this also means that repos with only a `"main"` branch are impossible to push to GitHub.


## Solution

This commit updates `ruby-git` and ensures that `web_git` pushes the current branch that the user is on.

### Install gem and test locally

```rb
gem "web_git", git: "https://github.com/firstdraft/web_git", branch: "jw-update-ruby-git"
```