### PR TITLE
Replace branch log with basic CLI graph

### DIFF
--- a/lib/views/status.erb
+++ b/lib/views/status.erb
@@ -289,29 +289,7 @@
               <% end%>            
             </form>
           </div>
-          <% @graph_branches.each do |branch_hash| %>
-            <h4 class="p-4"><%= branch_hash[:branch] %></h4>
-            <code class="bg-dark text-white p-3">
-              <% branch_hash[:log].reverse.each do |commit| %>
-              <div>
-                <span class="commit">
-                  <button class="btn btn-link sha"><%= commit[:sha] %></button>
-                </span>
-                — <%= commit[:date].strftime("%a, %d %b %Y, %H:%M %z") %> (<%= commit[:formatted_date] %> ago)
-                  <% heads = "(#{commit[:heads].join(", ")})" if !commit[:heads].empty? %>
-                  <% if commit[:heads].include? @current_branch %>
-                    <%= heads.gsub(@current_branch, '<span class="text-success">HEAD</span> --> ' + @current_branch) %>
-                  <% else %>
-                    <%= heads %>
-                  <% end %>
-                <div>
-                  &emsp; | <%= commit[:message] + " - " + commit[:author] %>
-                </div>
-              </div>
-              <% end %>
-            </code>
-            <hr>
-          <% end %>
+          <pre class="bg-dark text-white p-3"><%= @cli_graph_interactive %></pre>
         </div>
       </div>
     </div>

--- a/lib/web_git.rb
+++ b/lib/web_git.rb
@@ -70,6 +70,7 @@ module WebGit
 
       graph = WebGit::Graph.new(git)
       @graph_hash = graph.to_hash
+      @cli_graph_interactive = graph.cli_graph
       @graph_branches = @graph_hash.sort do |branch_a, branch_b|
         branch_b[:log].last[:date] <=> branch_a[:log].last[:date]
       end

--- a/lib/web_git/graph.rb
+++ b/lib/web_git/graph.rb
@@ -28,6 +28,31 @@ module WebGit
       @full_list
     end
 
+    def self.project_root
+      if defined?(Rails)
+        return Rails.root
+      end
+    
+      if defined?(Bundler)
+        return Bundler.root
+      end
+    
+      Dir.pwd
+    end
+
+    def cli_graph
+      Dir.chdir(Graph.project_root) do
+        @cli_graph = `git log --oneline --decorate --graph --all`
+        all_commits = `git log  --all --format=format:%H`.split("\n").map{|a| a.slice(0,7)}
+
+        all_commits.each do |sha|
+          sha_button = "<span class=\"commit\"><button class=\"btn btn-link sha\">#{sha}</button></span>"
+          @cli_graph.gsub!(sha, sha_button)
+        end
+      end
+      @cli_graph
+    end
+
     def has_untracked_changes?
       @git.diff.size > 0
     end


### PR DESCRIPTION
## Problem

> I was thinking as a stopgap until we figure out some sort of JS graphing library to display the git graph, should we go back to my old hack of displaying the output of git sla at the bottom of /git? I feel like the tree view (with all the branches unified) is essential
>
>The downside is that we'd have to install the command-line tools that the old web_git depended on

`git sla` being an alias of `git log --oneline --decorate --graph --all`

## Solution

Until it becomes feasible to draw the graph with the `git` gem, capture the output of the graph from the command line and display it below the commit form.

![git-cli-graph](https://user-images.githubusercontent.com/17581658/117377117-1e353e80-ae98-11eb-968f-5847a1e523db.gif)


### To test

1. Add gem to `Gemfile`

```rb
gem "web_git", git: "https://github.com/firstdraft/web_git", branch: "jw-basic-cli-graph"
```

2. Run install command

```bash
rails g web_git:install
```
 
3. Run `rails s`
4. Visit `/git`
