### PR TITLE
Add notice and alerts

### DIFF
--- a/lib/views/status.erb
+++ b/lib/views/status.erb
@@ -18,9 +18,9 @@
 </head>
 <body>
   <div class="container mt-3">
-    <% if !@alert.nil? || !@notice.nil? %>
-      <div class="row">
-        <div class="col-md-12">
+    <div class="row">
+      <div class="col-md-12">
+        <% if !@notice.nil? %>
           <div class="alert alert-success alert-dismissable" role="alert">
             <%= @notice %>
 
@@ -28,6 +28,7 @@
               <span aria-hidden="true">&times;</span>
             </button>
           </div>
+        <% elsif !@alert.nil? %>
 
           <div class="alert alert-warning alert-dismissable" role="alert">
             <%= @alert %>
@@ -36,9 +37,9 @@
               <span aria-hidden="true">&times;</span>
             </button>
           </div>
-        </div>
+        <% end %>
       </div>
-    <% end %>
+    </div>
     <div class="row mb-4">
       <div class="col">
         <div class="card">

--- a/lib/views/status.erb
+++ b/lib/views/status.erb
@@ -20,7 +20,7 @@
   <div class="container mt-3">
     <div class="row">
       <div class="col-md-12">
-        <% if !@notice.nil? %>
+        <% if @notice.present? %>
           <div class="alert alert-success alert-dismissable" role="alert">
             <%= @notice %>
 
@@ -28,7 +28,7 @@
               <span aria-hidden="true">&times;</span>
             </button>
           </div>
-        <% elsif !@alert.nil? %>
+        <% elsif @alert.present? %>
 
           <div class="alert alert-warning alert-dismissable" role="alert">
             <%= @alert %>

--- a/lib/views/status.erb
+++ b/lib/views/status.erb
@@ -18,6 +18,27 @@
 </head>
 <body>
   <div class="container mt-3">
+    <% if !@alert.nil? || !@notice.nil? %>
+      <div class="row">
+        <div class="col-md-12">
+          <div class="alert alert-success alert-dismissable" role="alert">
+            <%= @notice %>
+
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+
+          <div class="alert alert-warning alert-dismissable" role="alert">
+            <%= @alert %>
+
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    <% end %>
     <div class="row mb-4">
       <div class="col">
         <div class="card">

--- a/lib/web_git.rb
+++ b/lib/web_git.rb
@@ -9,6 +9,7 @@ module WebGit
   require "date"
   require "git"
   class Server < Sinatra::Base
+    enable :sessions
 
     get '/log' do
       working_dir = File.exist?(Dir.pwd + "/.git") ? Dir.pwd : Dir.pwd + "/.."
@@ -26,6 +27,12 @@ module WebGit
     end
     
     get "/" do
+      @alert = session[:alert]
+      @notice = session[:notice]
+      
+      session[:alert] = nil
+      session[:notice] = nil
+
       working_dir = File.exist?(Dir.pwd + "/.git") ? Dir.pwd : Dir.pwd + "/.."
       g = Git.open(working_dir)
       # Update git index
@@ -80,6 +87,10 @@ module WebGit
     post "/commit" do
       title = params[:title]
       description = params[:description]
+      if title.nil?
+        session[:alert] = "You need to make a commit message."
+        redirect to("/")
+      end
       working_dir = File.exist?(Dir.pwd + "/.git") ? Dir.pwd : Dir.pwd + "/.."
       g = Git.open(working_dir)
       g.add(:all => true)  
@@ -87,6 +98,9 @@ module WebGit
         title += "\n#{description}"
       end
       g.commit(title)
+      session[:notice] = "Commit created successfully."
+      p "session"
+      p session[:notice]
       redirect to("/")
     end
     
@@ -124,6 +138,7 @@ module WebGit
       g = Git.open(working_dir)
       name = params.fetch(:branch_name).downcase.gsub(" ", "_")
       g.branch(name).delete
+      session[:notice] = "Branch deleted successfully."
       redirect to("/")
     end
 
@@ -135,11 +150,12 @@ module WebGit
       g.push('origin', g.current_branch)
       redirect to("/")
     end
-
+    
     post "/pull" do
       working_dir = File.exist?(Dir.pwd + "/.git") ? Dir.pwd : Dir.pwd + "/.."
       g = Git.open(working_dir)
       g.pull
+      session[:notice] = "Pulled successfully."
       redirect to("/")
     end
   end

--- a/lib/web_git.rb
+++ b/lib/web_git.rb
@@ -12,10 +12,7 @@ module WebGit
     enable :sessions
 
     get '/log' do
-      working_dir = File.exist?(Dir.pwd + "/.git") ? Dir.pwd : Dir.pwd + "/.."
-      g = Git.open(working_dir)
-      
-      graph = WebGit::Graph.new(g)
+      graph = WebGit::Graph.new(git)
       graph.to_hash.to_json
       #sha = commit.sha.slice(0..7)
       # commit_date = Date.parse commit.date
@@ -25,21 +22,15 @@ module WebGit
 
       # " * " + sha + " - " + commit_date + " (" + time_ago_in_words(commit_date) + ") " + "\n\t| " + commit.message 
     end
-    
-    get "/" do
-      @alert = session[:alert]
-      @notice = session[:notice]
-      
-      session[:alert] = nil
-      session[:notice] = nil
 
-      working_dir = File.exist?(Dir.pwd + "/.git") ? Dir.pwd : Dir.pwd + "/.."
-      g = Git.open(working_dir)
+    get "/" do
+      initialize_flash
+      clear_flash
       # Update git index
-      g.status.changed.each do
-        g.diff.entries
+      git.status.changed.each do
+        git.diff.entries
       end
-      status = g.status
+      status = git.status
       # Just need the file names
       @changed_files = status.changed.keys
       @deleted_files = status.added.keys
@@ -53,29 +44,29 @@ module WebGit
         { name: "Added Files:", file_list: @added_files }
       ]
       
-      @current_branch = g.current_branch
+      @current_branch = git.current_branch
       # g.branch(@current_branch).checkout # maybe?
       @status = `git status`
-      @diff = g.diff
-      @diff = Diff.diff_to_html(g.diff.to_s)
+      @diff = git.diff
+      @diff = Diff.diff_to_html(git.diff.to_s)
       last_diff = nil
-      if g.log.count > 1
-        last_diff = g.diff(g.log[1], "HEAD").to_s + "\n"
+      if git.log.count > 1
+        last_diff = git.diff(git.log[1], "HEAD").to_s + "\n"
       end
       # @last_diff_html = Diff.last_to_html(last_diff)
       @last_diff_html = last_diff
-      @branches = g.branches.local.map(&:full)
+      @branches = git.branches.local.map(&:full)
       
-      logs = g.log
+      logs = git.log
       @last_commit_message = logs.first.message
-      @head = g.show.split("\n").first.split[1].slice(0..7)
+      @head = git.show.split("\n").first.split[1].slice(0..7)
       @list = []
       # (HEAD -> jw-non-sweet)
       # TODO show where branches are on different remotes
       # (origin/master, origin/jw-non-sweet, origin/HEAD)
-      # g.branches[:master].gcommit
+      # git.branches[:master].gcommit
 
-      graph = WebGit::Graph.new(g)
+      graph = WebGit::Graph.new(git)
       @graph_hash = graph.to_hash
       @graph_branches = @graph_hash.sort do |branch_a, branch_b|
         branch_b[:log].last[:date] <=> branch_a[:log].last[:date]
@@ -83,80 +74,115 @@ module WebGit
 
       erb :status
     end
-    
+
     post "/commit" do
       title = params[:title]
       description = params[:description]
-      if title.nil?
+
+      # TODO validate commit message
+      if title.nil? || title.gsub(" ", "").length == 0
         session[:alert] = "You need to make a commit message."
         redirect to("/")
       end
-      working_dir = File.exist?(Dir.pwd + "/.git") ? Dir.pwd : Dir.pwd + "/.."
-      g = Git.open(working_dir)
-      g.add(:all => true)  
+
       unless description.nil?
         title += "\n#{description}"
       end
-      g.commit(title)
-      session[:notice] = "Commit created successfully."
-      p "session"
-      p session[:notice]
+
+      safe_git_action(:commit, args: title, notice: "Commit created successfully", alert: "Failed to create commit")
       redirect to("/")
     end
-    
+
     get "/stash" do
-      working_dir = File.exist?(Dir.pwd + "/.git") ? Dir.pwd : Dir.pwd + "/.."
-      g = Git.open(working_dir)
-      g.add(:all=>true)
-      stash_count = Git::Stashes.new(g).count
-      Git::Stash.new(g, "Stash #{stash_count}")
+      safe_git_action(:stash, notice: "Changes stashed.", alert: "Failed to stash changes")
       redirect to("/")
     end
-    
+
     post "/branch/checkout/new" do
-      working_dir = File.exist?(Dir.pwd + "/.git") ? Dir.pwd : Dir.pwd + "/.."
-      g = Git.open(working_dir)
+      # TODO validate branch name
       name = params.fetch(:branch_name).downcase.gsub(" ", "_")
       commit = params.fetch(:commit_hash)
-      g.branch(name).checkout
-      g.reset_hard(g.gcommit(commit))
+
+      safe_git_action(:checkout, args: name, notice: "Branch #{name}, created successfully.", alert: "Failed to create branch")
+      safe_git_action(:reset_hard, args: commit, alert: "Failed to checkout branch at #{commit}")
       redirect to("/")
     end
-    
+
     post "/branch/checkout" do
-      working_dir = File.exist?(Dir.pwd + "/.git") ? Dir.pwd : Dir.pwd + "/.."
-      g = Git.open(working_dir)
       name = params.fetch(:branch_name).downcase.gsub(" ", "_")
-      g.branch(name).checkout
-      
+
+      safe_git_action(:checkout, args: name, notice: "Switched to branch: #{name} successfully.", alert: "Failed to switch branch")
       redirect to("/")
     end
-    
+
     # TODO make delete request somehow with the links
     post "/branch/delete" do
-      working_dir = File.exist?(Dir.pwd + "/.git") ? Dir.pwd : Dir.pwd + "/.."
-      g = Git.open(working_dir)
       name = params.fetch(:branch_name).downcase.gsub(" ", "_")
-      g.branch(name).delete
-      session[:notice] = "Branch deleted successfully."
+
+      safe_git_action(:delete, args: name, notice: "Deleted branch: #{name} successfully.", alert: "Failed to delete branch")
       redirect to("/")
     end
 
     post "/push" do
-      working_dir = File.exist?(Dir.pwd + "/.git") ? Dir.pwd : Dir.pwd + "/.."
-      g = Git.open(working_dir)
       # TODO push to heroku eventually, multiple remotes
 
-      g.push('origin', g.current_branch)
+      safe_git_action(:push, notice: "Pushed to GitHub successfully.", alert: "Failed to push")
       redirect to("/")
     end
-    
+
     post "/pull" do
-      working_dir = File.exist?(Dir.pwd + "/.git") ? Dir.pwd : Dir.pwd + "/.."
-      g = Git.open(working_dir)
-      g.pull
-      session[:notice] = "Pulled successfully."
+      safe_git_action(:pull, notice: "Pulled successfully.", alert: "Git Pull failed")
       redirect to("/")
+    end
+
+    protected
+
+    def git
+      working_dir = File.exist?(Dir.pwd + "/.git") ? Dir.pwd : Dir.pwd + "/.."
+      @git ||= Git.open(working_dir)
+    end
+
+    def safe_git_action(method, **options)
+      begin
+        case method
+        when :push
+          git.push('origin', git.current_branch)
+        when :pull
+          git.pull
+        when :stash
+          git.add(all: true)
+          stash_count = Git::Stashes.new(git).count
+          Git::Stash.new(git, "Stash #{stash_count}")
+        when :commit
+          git.add(all: true)  
+          git.commit(options[:args])
+        when :checkout
+          git.branch(options[:args]).checkout
+        when :reset_hard
+          commit = git.gcommit(options[:args])
+          git.reset_hard(commit)
+        when :delete
+          git.branch(options[:args]).delete          
+        end
+        set_flash(:notice, options[:notice])
+      rescue Git::GitExecuteError => exception
+        alert_message = "#{options[:alert]}: #{exception.message.split("\n").last}"
+        set_flash(:alert, alert_message)
+      end
+    end
+
+    def set_flash(name, message)
+      session[name] = message
+    end
+
+    def clear_flash
+      session[:alert] = nil
+      session[:notice] = nil
+    end
+
+    def initialize_flash
+      @alert = session[:alert]
+      @notice = session[:notice]
     end
   end
 end

--- a/lib/web_git.rb
+++ b/lib/web_git.rb
@@ -2,6 +2,7 @@
 require "web_git/version"
 
 module WebGit
+  require "active_support"
   require "web_git/diff"
   require "web_git/graph"
   require "web_git/string"


### PR DESCRIPTION
Resolves #78 
Resolves #88 

## Problem

Students often see a big ol' error page if Git or Gitpod settings aren't exactly right

![image](https://user-images.githubusercontent.com/17581658/120911703-f24fd900-c64e-11eb-9282-8ab54e37bd68.png)

Students should never see an error page like this. `web_git` should fail gracefully and redirect with a flash message if something doesn't work.

## Solution

This PR does the following:
- Enables `session` in Sinatra to display flash messages.
- Refactors controller logic to rescue `Git::GitExecuteError` exceptions
- Displays flash messages on redirect

![web-git-alert](https://user-images.githubusercontent.com/17581658/120911597-3bebf400-c64e-11eb-8fb0-42d1a3488517.gif)
