### PR TITLE
Display origin git remote

### DIFF
--- a/lib/views/status.erb
+++ b/lib/views/status.erb
@@ -126,6 +126,12 @@
 
               <div class="row">
                 <div class="col">
+                  <h6 class="card-subtitle mb-2 text-muted">
+                    <div>
+                    Remote:
+                    </div>
+                      <%= @remotes.first %>
+                  </h6>
                   <!-- TODO use git gem for status -->
                   <pre><%= @status %></pre>
                   

--- a/lib/web_git.rb
+++ b/lib/web_git.rb
@@ -65,6 +65,7 @@ module WebGit
       @list = []
       # (HEAD -> jw-non-sweet)
       # TODO show where branches are on different remotes
+      @remotes = g.remotes.map {|remote| "#{remote.name}: #{remote.url}"  }
       # (origin/master, origin/jw-non-sweet, origin/HEAD)
       # g.branches[:master].gcommit
 


### PR DESCRIPTION
Resolves #93 

![web-git-remote-display](https://user-images.githubusercontent.com/17581658/120945487-cdb33a00-c6fe-11eb-835d-7724e0b8fb82.png)

For now this just displays the `origin` remote, which is most useful. The graph should show other remotes due to changes in #95 . In a separate PR, we can add functionality to choose which remote to push to or how to best display all remotes.