### PR TITLE
Add color to git graph

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,9 @@ source "https://rubygems.org"
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.
 group :development do
-  gem "rspec", "~> 3.5.0"
-  gem "rdoc", "~> 3.12"
   gem "juwelier", "~> 2.1.0"
+  gem "rdoc", "~> 3.12"
+  gem "rspec", "~> 3.5.0"
 end
 
 gem "actionview"

--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,10 @@ group :development do
   gem "juwelier", "~> 2.1.0"
 end
 
-gem 'sinatra'
-gem "git"
-gem "diffy"
 gem "actionview"
+gem "ansispan"
+gem "diffy"
+gem "git"
+gem 'sinatra'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,6 @@ gem "actionview"
 gem "ansispan"
 gem "diffy"
 gem "git"
-gem 'sinatra'
+gem "sinatra"
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    ansispan (0.0.1)
     builder (3.2.3)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
@@ -122,6 +123,7 @@ PLATFORMS
 
 DEPENDENCIES
   actionview
+  ansispan
   diffy
   git
   juwelier (~> 2.1.0)

--- a/lib/web_git/graph.rb
+++ b/lib/web_git/graph.rb
@@ -1,5 +1,6 @@
 module WebGit
   require "git"
+  require "ansispan"
   
   class Graph
     require "action_view"
@@ -42,9 +43,10 @@ module WebGit
 
     def cli_graph
       Dir.chdir(Graph.project_root) do
-        @cli_graph = `git log --oneline --decorate --graph --all`
+        @cli_graph = `git log --oneline --decorate --graph --all --color`
         all_commits = `git log  --all --format=format:%H`.split("\n").map{|a| a.slice(0,7)}
 
+        @cli_graph = Ansispan.convert(@cli_graph)
         all_commits.each do |sha|
           sha_button = "<span class=\"commit\"><button class=\"btn btn-link sha\">#{sha}</button></span>"
           @cli_graph.gsub!(sha, sha_button)

--- a/web_git.gemspec
+++ b/web_git.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
   s.authors = ["Raghu Betina".freeze, "Jelani Woods".freeze]
-  s.date = "2020-06-19"
+  s.date = "2020-07-01"
   s.description = "WebGit is a Rails Engine that provides an in-browser visual interface to a simple but effective Git workflow. For educational purposes.".freeze
   s.email = "raghu@firstdraft.com".freeze
   s.extra_rdoc_files = [
@@ -51,10 +51,12 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<diffy>.freeze, [">= 0"])
       s.add_runtime_dependency(%q<actionview>.freeze, [">= 0"])
       s.add_runtime_dependency(%q<tzinfo-data>.freeze, [">= 0"])
+      s.add_runtime_dependency(%q<ansispan>.freeze, [">= 0"])
       s.add_development_dependency(%q<rspec>.freeze, ["~> 3.5.0"])
       s.add_development_dependency(%q<rdoc>.freeze, ["~> 3.12"])
       s.add_development_dependency(%q<juwelier>.freeze, ["~> 2.1.0"])
     else
+      s.add_dependency(%q<ansispan>.freeze, [">= 0"])
       s.add_dependency(%q<sinatra>.freeze, [">= 0"])
       s.add_dependency(%q<git>.freeze, [">= 0"])
       s.add_dependency(%q<diffy>.freeze, [">= 0"])
@@ -65,6 +67,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<juwelier>.freeze, ["~> 2.1.0"])
     end
   else
+    s.add_dependency(%q<ansispan>.freeze, [">= 0"])
     s.add_dependency(%q<sinatra>.freeze, [">= 0"])
     s.add_dependency(%q<git>.freeze, [">= 0"])
     s.add_dependency(%q<diffy>.freeze, [">= 0"])


### PR DESCRIPTION
Resolves #102 

## Problem

Showing the Git graph is less usefull without color.

## Solution

Add [`ansispan` gem](https://github.com/jelaniwoods/ansispan) to apply CSS color and style to the captured ansi-colored git graph while preserving the clickable SHAs.

<img width="1131" alt="Screen Shot 2021-07-02 at 10 14 12 AM" src="https://user-images.githubusercontent.com/17581658/124295269-40f17580-db1e-11eb-93f0-78e2dcbcad68.png">

### Install instructions


1. Add gem to `Gemfile`

```rb
gem "web_git", git: "https://github.com/firstdraft/web_git", branch: "102-jw-add-color-to-graph"
```

2. Run install command

```bash
rails g web_git:install
```
 
3. Run `rails s`
4. Visit `/git`
