### PR TITLE
Fix show last commit for projects with 1 commit

### DIFF
--- a/lib/web_git.rb
+++ b/lib/web_git.rb
@@ -50,11 +50,11 @@ module WebGit
       @status = `git status`
       @diff = git.diff
       @diff = Diff.diff_to_html(git.diff.to_s)
-      last_diff = nil
       if git.log.count > 1
         last_diff = git.diff("HEAD~1", "HEAD").to_s + "\n"
+        @last_diff_html = Diff.last_to_html(last_diff)
       end
-      @last_diff_html = Diff.last_to_html(last_diff)
+      @last_diff_html = ""
       @branches = git.branches.local.map(&:full)
       
       logs = git.log


### PR DESCRIPTION
Resolves #108 

## Problem

Due to changes in https://github.com/firstdraft/web_git/pull/105

When a project has 1 commit on the current branch `git show HEAD~1` was being called which throws an error since it requires a previous commit.

## Solution

Don't call `git show HEAD~1` when the log has one commit.