### PR TITLE
Add default homepage for non-Rails apps

### DIFF
--- a/lib/views/index.html
+++ b/lib/views/index.html
@@ -1,0 +1,4 @@
+<p style="font-size: 2rem;">
+  It looks like this project doesn't have a homepage.
+  Are you looking for the <a href="/git">/git</a> interface? Follow the link.
+</p>


### PR DESCRIPTION
Resolves #123 

## Problem
With the current usage instructions, non-Rails projects don't have a homepage and so starting the server they see a "No route matches" page.

There should instead be a default homepage with a link to navigate to the /git route.

This PR _does not_ update the install generator for non-Rails projects. Follow to #57 for that

## Setup instructions

Modify the `config.ru` in the parent project to look like this:

```ruby
require 'bundler/setup'
require "web_git"

map '/' do
  dir = Gem::Specification.find_by_name('web_git').gem_dir
  path = dir + '/lib/views/index.html'
  default_homepage = File.read(path)
  app = proc do |env|
    [200, { 'Content-Type' => 'text/html' }, [default_homepage]]
  end
  run app
end

map '/git' do
  run WebGit::Server
end

```