### PR TITLE
Hide ignored files from untracked changes

### DIFF
--- a/lib/web_git.rb
+++ b/lib/web_git.rb
@@ -36,7 +36,7 @@ module WebGit
       # Just need the file names
       @changed_files = status.changed.keys
       @deleted_files = status.added.keys
-      @untracked_files = status.untracked.keys
+      @untracked_files = untracked_files
       @added_files = status.deleted.keys
 
       @statuses = [
@@ -159,6 +159,11 @@ module WebGit
     def git
       working_dir = File.exist?(Dir.pwd + "/.git") ? Dir.pwd : Dir.pwd + "/.."
       @git ||= Git.open(working_dir)
+    end
+
+    # Temporary workaround for ruby-git bug
+    def untracked_files
+      `git --work-tree=#{git.dir} --git-dir=#{git.dir}/.git ls-files -o -z --full-name --exclude-standard`.split("\x0")
     end
 
     def safe_git_action(method, **options)


### PR DESCRIPTION
Resolves #126 

## Problem

Due to bug in `ruby-git`, untracked files **ignore** all `.gitignore`'d files. This wasn't a problem until we started bundling gems in the project. Now all the gems show up in the diff even though they don't get committed.

This is bad for a lot of reasons, but mostly just confusing for students when they make their first commit.

<img width="818" alt="Screen Shot 2022-04-21 at 12 31 24 PM" src="https://user-images.githubusercontent.com/17581658/164517638-dbb1b7de-fe58-4607-bedf-5d155f176cd8.png">


## Solution

This PR [implements a workaround](https://gist.github.com/msutter/776816f4e44f12facfda) suggested in a PR comment. This drops down to using command line `git`. I made a slight edit to work even if `.gitignore` is not present in the project directory. This is meant to be a temporary change until `ruby-git` fixes it.