### PR TITLE
Add config settings to control Heroku features

### DIFF
--- a/lib/views/status.erb
+++ b/lib/views/status.erb
@@ -71,7 +71,7 @@
         <a class="nav-link active" id="git-tab" href="#git">Git</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" id="heroku-tab" href="#heroku">Heroku</a>
+        <a class="nav-link <%= "disabled" if !heroku_authenticated? %>" id="heroku-tab" href="#heroku">Heroku</a>
       </li>
     </ul>
 
@@ -332,14 +332,14 @@
       <div class="tab-pane" id="heroku" role="tabpanel" aria-labelledby="home-tab">
         <ul class="list-group">
           <li class="list-group-item heroku text-white d-flex justify-content-between">
-            <% if @heroku_auth.empty? %>
+            <% if !heroku_authenticated? %>
               <span>Log in</span>
             <% else %>
               <span>Logged in as:</span>
               <span><%= @heroku_auth %></span>
             <% end %>
           </li>
-          <% if @heroku_auth.empty? %>
+          <% if !heroku_authenticated? %>
             <div class="border border-heroku p-4">
               <form action="/git/heroku/login" method="post">
                 <div class="form-group">

--- a/lib/views/status.erb
+++ b/lib/views/status.erb
@@ -71,7 +71,7 @@
         <a class="nav-link active" id="git-tab" href="#git">Git</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link <%= "disabled" if !heroku_authenticated? %>" id="heroku-tab" href="#heroku">Heroku</a>
+        <a class="nav-link <%= "disabled d-none" if !heroku_authenticated? %>" id="heroku-tab" href="#heroku">Heroku</a>
       </li>
     </ul>
 

--- a/lib/web_git.rb
+++ b/lib/web_git.rb
@@ -3,6 +3,7 @@ require "web_git/version"
 
 module WebGit
   require "active_support"
+  require "web_git/config"
   require "web_git/diff"
   require "web_git/graph"
   require "web_git/heroku"
@@ -77,7 +78,7 @@ module WebGit
       end
 
       # TODO heroku stuff
-      @heroku_auth = WebGit::Heroku.whoami
+      @heroku_auth = WebGit::Heroku.whoami if WebGit.heroku_enabled
       erb :status
     end
 
@@ -207,6 +208,10 @@ module WebGit
     def initialize_flash
       @alert = session[:alert]
       @notice = session[:notice]
+    end
+
+    def heroku_authenticated?
+      !@heroku_auth.nil? && !@heroku_auth.empty?
     end
   end
 end

--- a/lib/web_git/config.rb
+++ b/lib/web_git/config.rb
@@ -1,0 +1,12 @@
+module WebGit
+  class << self
+    attr_accessor :heroku_enabled
+    def heroku_enabled
+      @heroku_enabled || false
+    end
+
+    def config(&block)
+      yield self
+    end
+  end
+end


### PR DESCRIPTION
Resolves #141 

## Problem

The output of `heroku whomai` is confusing to students sometimes. We also don't plan to use Heroku for the foreseeable future, so running it preemptively is unnecessary.

## Solution

Add ability to turn on/off Heroku features in an initializer. The Heroku settings are **not enabled by default**. This disables the Heroku nav tab and doesn't call `heroku whoami`. 


In the installed project, create an initializer file (`web_git.rb`) and toggle the Heroku features like this:

```rb
WebGit.config do |config|
  config.heroku_enabled = true # is set to false by default
end
```